### PR TITLE
Use explicit connect/disconnect methods

### DIFF
--- a/listen_to_die.py
+++ b/listen_to_die.py
@@ -42,7 +42,7 @@ async def main():
     print(f"{sr=}")
     assert sr is not None
 
-    async with sr.hydrate() as die:
+    async with sr.hydrate().auto_reconnect() as die:
         @die.handler(...)
         def recv(msg):
             print(f"Received {msg}")

--- a/listen_to_die.py
+++ b/listen_to_die.py
@@ -42,7 +42,7 @@ async def main():
     print(f"{sr=}")
     assert sr is not None
 
-    async with sr.connect() as die:
+    async with sr.hydrate() as die:
         @die.handler(...)
         def recv(msg):
             print(f"Received {msg}")

--- a/nat20/__init__.py
+++ b/nat20/__init__.py
@@ -10,14 +10,15 @@ Primary interface to Pixels dice.
         die.blink_id(0x80)
 """
 import asyncio
-from collections.abc import AsyncIterable
+from collections.abc import AsyncGenerator, AsyncIterable
+import contextlib
 import dataclasses
 import datetime
 import enum
 import logging
 import struct
 from types import EllipsisType
-from typing import Union
+from typing import Self, Union
 
 import bleak
 
@@ -200,22 +201,33 @@ class Pixel(PixelLink):
         )
         super().__init__()
 
-    async def __aenter__(self):
+    async def connect(self) -> Self:
         """
         Connect to die
         """
         self._expected_disconnect = False
         await self._client.connect()
-        await super().__aenter__()
+        await super().connect()
         return self
 
-    async def __aexit__(self, *exc):
+    async def disconnect(self, *exc):
         """
         Disconnect from die
         """
-        await super().__aexit__(*exc)
+        await super().disconnect(*exc)
         self._expected_disconnect = True
         await self._client.disconnect()
+
+    @contextlib.asynccontextmanager
+    async def auto_reconnect(self) -> AsyncGenerator[Self, None]:
+        """
+        Connect to the die and make an effort to automatically reconnect.
+        """
+        await self.connect()
+        try:
+            yield self
+        finally:
+            await self.disconnect()
 
     async def _on_disconnect(self, client):
         if not self._expected_disconnect:  # Don't reconnect if we're exiting

--- a/nat20/__init__.py
+++ b/nat20/__init__.py
@@ -127,7 +127,7 @@ class ScanResult:
             percent=self.batt_level,
         )
 
-    def connect(self) -> 'Pixel':
+    def hydrate(self) -> 'Pixel':
         """
         Constructs a full Pixel class for this die.
         """

--- a/nat20/link.py
+++ b/nat20/link.py
@@ -152,7 +152,7 @@ class PixelLink:
         self._wait_queue = collections.defaultdict(list)
         self._message_handlers = collections.defaultdict(list)
 
-    async def __aenter__(self):
+    async def connect(self):
         """
         Does the bits necessary to start receiving stuff.
         """
@@ -162,7 +162,7 @@ class PixelLink:
         # assert mtu >= 517, f"Insufficient MTU ({mtu} < 517)"
         await self._client.start_notify(CHARI_NOTIFY, self._recv_notify)
 
-    async def __aexit__(self, *exc):
+    async def disconnect(self, *exc):
         """
         Does the bits necessary to stop receiving stuff.
         """

--- a/pixelize/__init__.py
+++ b/pixelize/__init__.py
@@ -59,7 +59,7 @@ class DieSummary(Static):
 
 
 class Die(Static):
-    _scan_result = None
+    _scan_result: ScanResult
 
     def update_from_result(self, sr: ScanResult):
         self._scan_result = sr
@@ -72,11 +72,11 @@ class Die(Static):
 
     @on(Button.Pressed, '#connect')
     def on_connect(self):
-        es = contextlib.AsyncExitStack()
+        die = self._scan_result.hydrate()
 
         async def connect():
             print("connecting")
-            return await es.enter_async_context(self._scan_result.hydrate())
+            return await die.connect()
 
         def switch(die):
             print("Open the dice now hal")
@@ -87,7 +87,7 @@ class Die(Static):
 
         def disconnect(*_):
             print("disconnecting")
-            asyncio.create_task(es.aclose())
+            asyncio.create_task(die.disconnect())
 
         self.app.push_screen(
             WorkingModal("Connecting", connect()),

--- a/pixelize/__init__.py
+++ b/pixelize/__init__.py
@@ -76,7 +76,7 @@ class Die(Static):
 
         async def connect():
             print("connecting")
-            return await es.enter_async_context(self._scan_result.connect())
+            return await es.enter_async_context(self._scan_result.hydrate())
 
         def switch(die):
             print("Open the dice now hal")

--- a/pixelize/__init__.py
+++ b/pixelize/__init__.py
@@ -1,5 +1,4 @@
 import asyncio
-import contextlib
 
 from textual import work, on
 from textual.app import App

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -18,7 +18,8 @@ async def test_who():
         else:
             assert False
 
-        async with sr.hydrate() as device:
-            iam = await device.who_are_you()
+        device = sr.hydrate()
+        await device.connect()
+        iam = await device.who_are_you()
 
     assert iam

--- a/tests/test_device.py
+++ b/tests/test_device.py
@@ -18,7 +18,7 @@ async def test_who():
         else:
             assert False
 
-        async with sr.connect() as device:
+        async with sr.hydrate() as device:
             iam = await device.who_are_you()
 
     assert iam


### PR DESCRIPTION
This is to enable the user to have better control of when connecting happens and have a sensible handling of disconnect events.